### PR TITLE
Help Xcode 8 to build & pass the unit tests

### DIFF
--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -105,6 +105,15 @@ private let dateFormatter: DateFormatter = {
 }()
 
 #if _runtime(_ObjC)
+#if swift(>=3)
+extension Date: NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        get {
+            return self.timeIntervalSinceReferenceDate
+        }
+    }
+}
+#else
 extension NSDate: NMBDoubleConvertible {
     public var doubleValue: CDouble {
         get {
@@ -112,7 +121,8 @@ extension NSDate: NMBDoubleConvertible {
         }
     }
 }
-#endif
+#endif // swift >= 3.0
+#endif // _runtime(_ObjC)
 
 extension NSDate: TestOutputStringConvertible {
     public var testDescription: String {

--- a/Sources/Nimble/Matchers/PostNotification.swift
+++ b/Sources/Nimble/Matchers/PostNotification.swift
@@ -36,7 +36,7 @@ internal class NotificationCollector {
 
 private let mainThread = pthread_self()
 
-public func postNotifications<T where T: Matcher, T.ValueType == [NSNotification]>(
+public func postNotifications<T where T: Matcher, T.ValueType == [NSNotification.Name]>(
     _ notificationsMatcher: T,
     fromNotificationCenter center: NotificationCenter = .default())
     -> MatcherFunc<Any> {
@@ -46,7 +46,7 @@ public func postNotifications<T where T: Matcher, T.ValueType == [NSNotification
         var once: Bool = false
         return MatcherFunc { actualExpression, failureMessage in
             let collectorNotificationsExpression = Expression(memoizedExpression: { _ in
-                return collector.observedNotifications
+                return collector.observedNotifications.map { $0.name }
                 }, location: actualExpression.location, withoutCaching: true)
 
             assert(pthread_equal(mainThread, pthread_self()) != 0, "Only expecting closure to be evaluated on main thread.")
@@ -59,7 +59,7 @@ public func postNotifications<T where T: Matcher, T.ValueType == [NSNotification
             if collector.observedNotifications.isEmpty {
                 failureMessage.actualValue = "no notifications"
             } else {
-                failureMessage.actualValue = "<\(stringify(collector.observedNotifications))>"
+                failureMessage.actualValue = "<\(stringify(collector.observedNotifications.map { $0.name }))>"
             }
             return match
         }

--- a/Tests/Nimble/Matchers/EqualTest.swift
+++ b/Tests/Nimble/Matchers/EqualTest.swift
@@ -151,8 +151,7 @@ final class EqualTest: XCTestCase, XCTestCaseProvider {
             // FIXME: Swift on Linux triggers a segfault when calling NSData's hash() (last checked on 03-11)
             let expectedErrorMessage = "expected to equal <NSData<length=9>>, got <NSData<length=6>>"
         #else
-            let expectedErrorMessage = "expected to equal <NSData<hash=92856895,length=9>>,"
-                + " got <NSData<hash=114710658,length=6>>"
+            let expectedErrorMessage = "expected to equal <<666f6f62 6172666f 6f>>, got <<666f6f62 6172>>"
         #endif
 
         failsWithErrorMessage(expectedErrorMessage) {

--- a/Tests/Nimble/Matchers/PostNotificationTest.swift
+++ b/Tests/Nimble/Matchers/PostNotificationTest.swift
@@ -28,7 +28,7 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
         let testNotification = Notification(name: Notification.Name("Foo"), object: nil)
         expect {
             self.notificationCenter.post(testNotification)
-        }.to(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(equal([testNotification.name]), fromNotificationCenter: notificationCenter))
     }
 
     func testPassesWhenAllExpectedNotificationsArePosted() {
@@ -40,38 +40,38 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
             self.notificationCenter.post(n1)
             self.notificationCenter.post(n2)
             return nil
-        }.to(postNotifications(equal([n1, n2]), fromNotificationCenter: notificationCenter))
+        }.to(postNotifications(equal([n1.name, n2.name]), fromNotificationCenter: notificationCenter))
     }
 
     func testFailsWhenNoNotificationsArePosted() {
         let testNotification = Notification(name: Notification.Name("Foo"), object: nil)
-        failsWithErrorMessage("expected to equal <[\(testNotification)]>, got no notifications") {
+        failsWithErrorMessage("expected to equal <[Name(_rawValue: \(testNotification.name.rawValue))]>, got no notifications") {
             expect {
                 // no notifications here!
                 return nil
-            }.to(postNotifications(equal([testNotification]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([testNotification.name]), fromNotificationCenter: self.notificationCenter))
         }
     }
 
     func testFailsWhenNotificationWithWrongNameIsPosted() {
         let n1 = Notification(name: Notification.Name("Foo"), object: nil)
         let n2 = Notification(name: Notification.Name(n1.name.rawValue + "a"), object: nil)
-        failsWithErrorMessage("expected to equal <[\(n1)]>, got <[\(n2)]>") {
+        failsWithErrorMessage("expected to equal <[Name(_rawValue: \(n1.name.rawValue))]>, got <[Name(_rawValue: \(n2.name.rawValue))]>") {
             expect {
                 self.notificationCenter.post(n2)
                 return nil
-            }.to(postNotifications(equal([n1]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([n1.name]), fromNotificationCenter: self.notificationCenter))
         }
     }
 
     func testFailsWhenNotificationWithWrongObjectIsPosted() {
         let n1 = Notification(name: Notification.Name("Foo"), object: nil)
         let n2 = Notification(name: n1.name, object: NSObject())
-        failsWithErrorMessage("expected to equal <[\(n1)]>, got <[\(n2)]>") {
+        failsWithErrorMessage("expected to equal <[Name(_rawValue: \(n1.name.rawValue))]>, got <[Name(_rawValue: \(n2.name.rawValue))]>") {
             expect {
                 self.notificationCenter.post(n2)
                 return nil
-            }.to(postNotifications(equal([n1]), fromNotificationCenter: self.notificationCenter))
+            }.to(postNotifications(equal([n1.name]), fromNotificationCenter: self.notificationCenter))
         }
     }
 
@@ -83,7 +83,7 @@ final class PostNotificationTest: XCTestCase, XCTestCaseProvider {
                     self.notificationCenter.post(testNotification)
                 }
                 return nil
-            }.toEventually(postNotifications(equal([testNotification]), fromNotificationCenter: notificationCenter))
+            }.toEventually(postNotifications(equal([testNotification.name]), fromNotificationCenter: notificationCenter))
         #else
             print("\(#function) is missing because toEventually is not implement on this platform")
         #endif

--- a/Tests/Nimble/Matchers/RaisesExceptionTest.swift
+++ b/Tests/Nimble/Matchers/RaisesExceptionTest.swift
@@ -14,7 +14,7 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
         ]
     }
 
-    var anException = NSException(name: "laugh", reason: "Lulz", userInfo: ["key": "value"])
+    var anException = NSException(name: "laugh" as NSExceptionName, reason: "Lulz", userInfo: ["key": "value"])
 
     func testPositiveMatches() {
         expect { self.anException.raise() }.to(raiseException())
@@ -25,64 +25,64 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
 
     func testPositiveMatchesWithClosures() {
         expect { self.anException.raise() }.to(raiseException { (exception: NSException) in
-            expect(exception.name).to(equal("laugh"))
+            expect(exception.name).to(equal("laugh" as NSExceptionName))
         })
         expect { self.anException.raise() }.to(raiseException(named: "laugh") { (exception: NSException) in
-            expect(exception.name).to(beginWith("lau"))
+            expect(exception.name.rawValue).to(beginWith("lau"))
         })
         expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz") { (exception: NSException) in
-            expect(exception.name).to(beginWith("lau"))
+            expect(exception.name.rawValue).to(beginWith("lau"))
         })
         expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { (exception: NSException) in
-            expect(exception.name).to(beginWith("lau"))
+            expect(exception.name.rawValue).to(beginWith("lau"))
         })
 
         expect { self.anException.raise() }.to(raiseException(named: "laugh") { (exception: NSException) in
-            expect(exception.name).toNot(beginWith("as"))
+            expect(exception.name.rawValue).toNot(beginWith("as"))
         })
         expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz") { (exception: NSException) in
-            expect(exception.name).toNot(beginWith("df"))
+            expect(exception.name.rawValue).toNot(beginWith("df"))
         })
         expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { (exception: NSException) in
-            expect(exception.name).toNot(beginWith("as"))
+            expect(exception.name.rawValue).toNot(beginWith("as"))
         })
     }
 
     func testNegativeMatches() {
-        failsWithErrorMessage("expected to raise exception with name <foo>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception with name <foo>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.to(raiseException(named: "foo"))
         }
 
-        failsWithErrorMessage("expected to raise exception with name <laugh> with reason <bar>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception with name <laugh> with reason <bar>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "bar"))
         }
 
         failsWithErrorMessage(
-            "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{k = v;}>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+            "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{k = v;}>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["k": "v"]))
         }
 
         failsWithErrorMessage("expected to raise any exception, got no exception") {
             expect { self.anException }.to(raiseException())
         }
-        failsWithErrorMessage("expected to not raise any exception, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.toNot(raiseException())
         }
         failsWithErrorMessage("expected to raise exception with name <laugh> with reason <Lulz>, got no exception") {
             expect { self.anException }.to(raiseException(named: "laugh", reason: "Lulz"))
         }
 
-        failsWithErrorMessage("expected to raise exception with name <bar> with reason <Lulz>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception with name <bar> with reason <Lulz>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.to(raiseException(named: "bar", reason: "Lulz"))
         }
-        failsWithErrorMessage("expected to not raise exception with name <laugh>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.toNot(raiseException(named: "laugh"))
         }
-        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz"))
         }
 
-        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}>, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}>, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.toNot(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]))
         }
     }
@@ -90,75 +90,75 @@ final class RaisesExceptionTest: XCTestCase, XCTestCaseProvider {
     func testNegativeMatchesDoNotCallClosureWithoutException() {
         failsWithErrorMessage("expected to raise exception that satisfies block, got no exception") {
             expect { self.anException }.to(raiseException { (exception: NSException) in
-                expect(exception.name).to(equal("foo"))
+                expect(exception.name).to(equal("foo" as NSExceptionName))
             })
         }
         
         failsWithErrorMessage("expected to raise exception with name <foo> that satisfies block, got no exception") {
             expect { self.anException }.to(raiseException(named: "foo") { (exception: NSException) in
-                expect(exception.name).to(equal("foo"))
+                expect(exception.name.rawValue).to(equal("foo"))
             })
         }
 
         failsWithErrorMessage("expected to raise exception with name <foo> with reason <ha> that satisfies block, got no exception") {
             expect { self.anException }.to(raiseException(named: "foo", reason: "ha") { (exception: NSException) in
-                expect(exception.name).to(equal("foo"))
+                expect(exception.name.rawValue).to(equal("foo"))
             })
         }
 
         failsWithErrorMessage("expected to raise exception with name <foo> with reason <Lulz> with userInfo <{}> that satisfies block, got no exception") {
             expect { self.anException }.to(raiseException(named: "foo", reason: "Lulz", userInfo: [:]) { (exception: NSException) in
-                expect(exception.name).to(equal("foo"))
+                expect(exception.name.rawValue).to(equal("foo"))
                 })
         }
 
-        failsWithErrorMessage("expected to not raise any exception, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.toNot(raiseException())
         }
     }
 
     func testNegativeMatchesWithClosure() {
-        failsWithErrorMessage("expected to raise exception that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }") {
+        failsWithErrorMessage("expected to raise exception that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }") {
             expect { self.anException.raise() }.to(raiseException { (exception: NSException) in
-                expect(exception.name).to(equal("foo"))
+                expect(exception.name.rawValue).to(equal("foo"))
             })
         }
 
         let innerFailureMessage = "expected to begin with <fo>, got <laugh>"
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "laugh") { (exception: NSException) in
-                expect(exception.name).to(beginWith("fo"))
+                expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "lol") { (exception: NSException) in
-                expect(exception.name).to(beginWith("fo"))
+                expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz") { (exception: NSException) in
-                expect(exception.name).to(beginWith("fo"))
+                expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <wrong> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <wrong> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "lol", reason: "wrong") { (exception: NSException) in
-                expect(exception.name).to(beginWith("fo"))
+                expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <laugh> with reason <Lulz> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "laugh", reason: "Lulz", userInfo: ["key": "value"]) { (exception: NSException) in
-                expect(exception.name).to(beginWith("fo"))
+                expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
 
-        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <Lulz> with userInfo <{}> that satisfies block, got NSException { name=laugh, reason='Lulz', userInfo=[key: value] }"]) {
+        failsWithErrorMessage([innerFailureMessage, "expected to raise exception with name <lol> with reason <Lulz> with userInfo <{}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: laugh), reason='Lulz', userInfo=[key: value] }"]) {
             expect { self.anException.raise() }.to(raiseException(named: "lol", reason: "Lulz", userInfo: [:]) { (exception: NSException) in
-                expect(exception.name).to(beginWith("fo"))
+                expect(exception.name.rawValue).to(beginWith("fo"))
             })
         }
     }

--- a/Tests/Nimble/objc/ObjCRaiseExceptionTest.m
+++ b/Tests/Nimble/objc/ObjCRaiseExceptionTest.m
@@ -80,7 +80,7 @@
                               userInfo(@{@"k": @"v"}));
     });
 
-    expectFailureMessage(@"expected to not raise any exception, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }", ^{
+    expectFailureMessage(@"expected to not raise any exception, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }", ^{
         expectAction(^{ [exception raise]; }).toNot(raiseException());
     });
 }
@@ -96,7 +96,7 @@
         }));
     });
 
-    NSString *outerFailureMessage = @"expected to raise exception that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
+    NSString *outerFailureMessage = @"expected to raise exception that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  satisfyingBlock(^(NSException *exception) {
@@ -104,7 +104,7 @@
         }));
     });
 
-    outerFailureMessage = @"expected to raise exception with name <foo> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <foo> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(@"foo").
@@ -113,7 +113,7 @@
         }));
     });
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <bar> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <bar> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -123,7 +123,7 @@
         }));
     });
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{}> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -142,7 +142,7 @@
     NSString *outerFailureMessage;
 
     NSString const *innerFailureMessage = @"expected to equal <foo>, got <NSInvalidArgumentException>";
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -152,7 +152,7 @@
     });
 
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).
@@ -163,7 +163,7 @@
     });
 
 
-    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSInvalidArgumentException, reason='No food', userInfo=[key: value] }";
+    outerFailureMessage = @"expected to raise exception with name <NSInvalidArgumentException> with reason <No food> with userInfo <{key = value;}> that satisfies block, got NSException { name=NSExceptionName(_rawValue: NSInvalidArgumentException), reason='No food', userInfo=[key: value] }";
     expectFailureMessages((@[outerFailureMessage, innerFailureMessage]), ^{
         expectAction(^{ [exception raise]; }).to(raiseException().
                                                  named(NSInvalidArgumentException).


### PR DESCRIPTION
There were a number of issues that led to Nimble not compiling & passing tests with Xcode 8, but the majority were differences in the way that NSNotification (now Notification) handles equality testing now, and how they are formatted in the expected failure messages.

This was tested successfully on Xcode 8 targeting both iOS and macOS targets.