### PR TITLE
CGFloat now conforms to NMBDoubleConvertible

### DIFF
--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -1,5 +1,7 @@
 import Foundation
-import CoreGraphics
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    import CoreGraphics
+#endif
 
 /// Implement this protocol to implement a custom matcher for Swift
 public protocol Matcher {
@@ -96,14 +98,16 @@ extension Float : NMBDoubleConvertible {
     }
 }
 
-extension CGFloat: NMBDoubleConvertible {
-    public var doubleValue: CDouble {
-        get {
-            return CDouble(self)
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    extension CGFloat: NMBDoubleConvertible {
+        public var doubleValue: CDouble {
+            get {
+                return CDouble(self)
+            }
         }
     }
-}
-
+#endif
+    
 extension NSNumber : NMBDoubleConvertible {
 }
 

--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreGraphics
 
 /// Implement this protocol to implement a custom matcher for Swift
 public protocol Matcher {
@@ -88,6 +89,14 @@ extension Double : NMBDoubleConvertible {
 }
 
 extension Float : NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        get {
+            return CDouble(self)
+        }
+    }
+}
+
+extension CGFloat: NMBDoubleConvertible {
     public var doubleValue: CDouble {
         get {
             return CDouble(self)

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -16,6 +16,7 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
             ("testBeCloseToWithinOperatorWithDate", testBeCloseToWithinOperatorWithDate),
             ("testPlusMinusOperatorWithDate", testPlusMinusOperatorWithDate),
             ("testBeCloseToArray", testBeCloseToArray),
+            ("testBeCloseToWithCGFloat", testBeCloseToWithCGFloat),
         ]
     }
 
@@ -23,7 +24,6 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(1.2).to(beCloseTo(1.2001))
         expect(1.2 as CDouble).to(beCloseTo(1.2001))
         expect(1.2 as Float).to(beCloseTo(1.2001))
-        expect(CGFloat(1.2)).to(beCloseTo(1.2001))
 
         failsWithErrorMessage("expected to not be close to <1.2001> (within 0.0001), got <1.2>") {
             expect(1.2).toNot(beCloseTo(1.2001))
@@ -46,6 +46,17 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         failsWithErrorMessage("expected to not be close to <1.2001> (within 1), got <1.2>") {
             expect(NSNumber(value:1.2)).toNot(beCloseTo(1.2001, within: 1.0))
         }
+    }
+    
+    func testBeCloseToWithCGFloat() {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            expect(CGFloat(1.2)).to(beCloseTo(1.2001))
+            expect(CGFloat(1.2)).to(beCloseTo(CGFloat(1.2001)))
+            
+            failsWithErrorMessage("expected to be close to <1.2001> (within 1), got <1.2>") {
+                expect(CGFloat(1.2)).to(beCloseTo(1.2001, within: 1.0))
+            }
+        #endif
     }
     
     func testBeCloseToWithDate() {

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -23,6 +23,7 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(1.2).to(beCloseTo(1.2001))
         expect(1.2 as CDouble).to(beCloseTo(1.2001))
         expect(1.2 as Float).to(beCloseTo(1.2001))
+        expect(CGFloat(1.2)).to(beCloseTo(1.2001))
 
         failsWithErrorMessage("expected to not be close to <1.2001> (within 0.0001), got <1.2>") {
             expect(1.2).toNot(beCloseTo(1.2001))


### PR DESCRIPTION
@norio-nomura Not sure if there's any meaningful test to add to this. What do you think?