### PR TITLE
Add NMBDoubleConvertible conformance to CGFloat on Linux

### DIFF
--- a/Sources/Nimble/Matchers/MatcherProtocols.swift
+++ b/Sources/Nimble/Matchers/MatcherProtocols.swift
@@ -1,5 +1,6 @@
 import Foundation
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+// `CGFloat` is in Foundation (swift-corelibs-foundation) on Linux.
+#if _runtime(_ObjC)
     import CoreGraphics
 #endif
 
@@ -84,30 +85,22 @@ public protocol NMBDoubleConvertible {
 
 extension Double : NMBDoubleConvertible {
     public var doubleValue: CDouble {
-        get {
-            return self
-        }
+        return self
     }
 }
 
 extension Float : NMBDoubleConvertible {
     public var doubleValue: CDouble {
-        get {
-            return CDouble(self)
-        }
+        return CDouble(self)
     }
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-    extension CGFloat: NMBDoubleConvertible {
-        public var doubleValue: CDouble {
-            get {
-                return CDouble(self)
-            }
-        }
+extension CGFloat: NMBDoubleConvertible {
+    public var doubleValue: CDouble {
+        return CDouble(self)
     }
-#endif
-    
+}
+
 extension NSNumber : NMBDoubleConvertible {
 }
 

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -49,16 +49,14 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
     }
     
     func testBeCloseToWithCGFloat() {
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-            expect(CGFloat(1.2)).to(beCloseTo(1.2001))
-            expect(CGFloat(1.2)).to(beCloseTo(CGFloat(1.2001)))
-            
-            failsWithErrorMessage("expected to be close to <1.2001> (within 1), got <1.2>") {
-                expect(CGFloat(1.2)).to(beCloseTo(1.2001, within: 1.0))
-            }
-        #endif
+        expect(CGFloat(1.2)).to(beCloseTo(1.2001))
+        expect(CGFloat(1.2)).to(beCloseTo(CGFloat(1.2001)))
+
+        failsWithErrorMessage("expected to be close to <1.2001> (within 1), got <1.2>") {
+            expect(CGFloat(1.2)).to(beCloseTo(1.2001, within: 1.0))
+        }
     }
-    
+
     func testBeCloseToWithDate() {
         expect(Date(dateTimeString: "2015-08-26 11:43:00")).to(beCloseTo(Date(dateTimeString: "2015-08-26 11:43:05"), within: 10))
         

--- a/Tests/NimbleTests/Matchers/BeCloseToTest.swift
+++ b/Tests/NimbleTests/Matchers/BeCloseToTest.swift
@@ -52,7 +52,13 @@ final class BeCloseToTest: XCTestCase, XCTestCaseProvider {
         expect(CGFloat(1.2)).to(beCloseTo(1.2001))
         expect(CGFloat(1.2)).to(beCloseTo(CGFloat(1.2001)))
 
-        failsWithErrorMessage("expected to be close to <1.2001> (within 1), got <1.2>") {
+        let got: String
+        #if _runtime(_ObjC)
+            got = "1.2"
+        #else
+            got = "CGFloat(native: 1.2)"
+        #endif
+        failsWithErrorMessage("expected to be close to <1.2001> (within 1), got <\(got)>") {
             expect(CGFloat(1.2)).to(beCloseTo(1.2001, within: 1.0))
         }
     }


### PR DESCRIPTION
`CGFloat` is in Foundation (swift-corelibs-foundation) on Linux.
